### PR TITLE
feat: add auth layer

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,7 @@
 LOG_LEVEL=debug
 NODE_ENV=development
 
+JWT_SECRET=secret
+LEGACY_JWT_SECRET=legacy_jwt_secret
+
 PORT=3000

--- a/bin/server.ts
+++ b/bin/server.ts
@@ -38,7 +38,8 @@ const routeInfo = getRouteInfo(container)
 
 console.log(prettyjson.render({ routes: routeInfo }))
 
-const env: Env = container.get(TYPES.Env)
+const env: Env = new Env()
+env.load()
 
 serverInstance.listen(env.get('PORT'))
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "express-winston": "^4.0.5",
     "inversify": "^5.0.1",
     "inversify-express-utils": "^6.3.2",
+    "jsonwebtoken": "^8.5.1",
     "prettyjson": "^1.2.1",
     "reflect-metadata": "^0.1.13",
     "winston": "^3.3.3"
@@ -35,6 +36,7 @@
     "@types/express": "^4.17.9",
     "@types/inversify-express-utils": "^2.0.0",
     "@types/jest": "^26.0.15",
+    "@types/jsonwebtoken": "^8.5.0",
     "@types/prettyjson": "^0.0.29",
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",

--- a/src/Bootstrap/Container.ts
+++ b/src/Bootstrap/Container.ts
@@ -3,15 +3,23 @@ import { Container, interfaces } from 'inversify'
 import { InMemoryRevisionRepository } from '../Infra/InMemory/InMemoryRevisionRepository'
 import { Env } from './Env'
 import TYPES from './Types'
+import { AuthMiddleware } from '../Controller/AuthMiddleware'
+import { AuthenticateUser } from '../Domain/UseCase/AuthenticateUser'
+import { InMemorySessionRepository } from '../Infra/InMemory/InMemorySessionRepository'
+import { InMemoryUserRepository } from '../Infra/InMemory/InMemoryUserRepository'
 
 export class ContainerConfigLoader {
     public static Load(): Container {
+        const env: Env = new Env()
+        env.load()
+
         const container = new Container()
         container.bind<InMemoryRevisionRepository>(TYPES.RevisionRepository).to(InMemoryRevisionRepository)
-        container.bind<Env>(TYPES.Env).to(Env)
-        container.bind<interfaces.Factory<winston.Logger>>(TYPES.LoggerFactory).toFactory<winston.Logger>((context: interfaces.Context) => {
+
+        container.bind<AuthMiddleware>(TYPES.AuthMiddleware).to(AuthMiddleware)
+
+        container.bind<interfaces.Factory<winston.Logger>>(TYPES.LoggerFactory).toFactory<winston.Logger>((_context: interfaces.Context) => {
           return () => {
-            const env: Env = context.container.get(TYPES.Env)
             const logLevel = env.get('LOG_LEVEL') || 'info'
 
             return  winston.createLogger({
@@ -26,6 +34,14 @@ export class ContainerConfigLoader {
             })
           }
         })
+
+        container.bind<AuthenticateUser>(TYPES.AuthenticateUser).to(AuthenticateUser)
+
+        container.bind<InMemorySessionRepository>(TYPES.SessionRepository).to(InMemorySessionRepository)
+        container.bind<InMemoryUserRepository>(TYPES.UserRepository).to(InMemoryUserRepository)
+
+        container.bind(TYPES.JWT_SECRET).toConstantValue(env.get('JWT_SECRET'))
+        container.bind(TYPES.LEGACY_JWT_SECRET).toConstantValue(env.get('LEGACY_JWT_SECRET'))
 
         return container
     }

--- a/src/Bootstrap/Types.ts
+++ b/src/Bootstrap/Types.ts
@@ -1,7 +1,12 @@
 const TYPES = {
   RevisionRepository: Symbol.for('RevisionRepository'),
-  Env: Symbol.for('Env'),
-  LoggerFactory: Symbol.for('LoggerFactory')
+  LoggerFactory: Symbol.for('LoggerFactory'),
+  AuthMiddleware: Symbol.for('AuthMiddleware'),
+  AuthenticateUser: Symbol.for('AuthenticateUser'),
+  JWT_SECRET: Symbol.for('JWT_SECRET'),
+  LEGACY_JWT_SECRET: Symbol.for('LEGACY_JWT_SECRET'),
+  UserRepository: Symbol.for('UserRepository'),
+  SessionRepository: Symbol.for('SessionRepository'),
 }
 
 export default TYPES

--- a/src/Controller/AuthMiddleware.spec.ts
+++ b/src/Controller/AuthMiddleware.spec.ts
@@ -1,0 +1,102 @@
+import 'reflect-metadata'
+
+import * as winston from 'winston'
+
+import { AuthMiddleware } from './AuthMiddleware'
+import { AuthenticateUser } from '../Domain/UseCase/AuthenticateUser'
+import { NextFunction, Request, Response } from 'express'
+import { User } from '../Domain/User/User'
+
+describe('AuthMiddleware', () => {
+  let loggerFactory: () => winston.Logger
+  let authenticateUser: AuthenticateUser
+  let request: Request
+  let response: Response
+  let next: NextFunction
+
+  const createMiddleware = () => new AuthMiddleware(authenticateUser, loggerFactory)
+
+  beforeEach(() => {
+    authenticateUser = {} as jest.Mocked<AuthenticateUser>
+    authenticateUser.execute = jest.fn()
+
+    const logger = {} as jest.Mocked<winston.Logger>
+    logger.info = jest.fn()
+    logger.warn = jest.fn()
+    logger.error = jest.fn()
+    loggerFactory = jest.fn().mockReturnValue(logger)
+
+    request = {
+      headers: {}
+    } as jest.Mocked<Request>
+    response = {
+      locals: {}
+    } as jest.Mocked<Response>
+    response.status = jest.fn().mockReturnThis()
+    response.send = jest.fn()
+    next = jest.fn()
+  })
+
+  it('should authorize user based on a jwt token', async () => {
+    request.headers.authorization = 'Bearer test'
+
+    const user = {} as jest.Mocked<User>
+    authenticateUser.execute = jest.fn().mockReturnValue({
+      success: true,
+      user: user
+    })
+
+    await createMiddleware().handler(request, response, next)
+
+    expect(response.locals.user).toEqual(user)
+
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should not authorize if authorization header is missing', async () => {
+    await createMiddleware().handler(request, response, next)
+
+    expect(response.status).toHaveBeenCalledWith(401)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('should not authorize if an error occurres', async () => {
+    request.headers.authorization = 'Bearer test'
+    authenticateUser.execute = jest.fn().mockImplementation(() => {
+      throw new Error('something bad happened')
+    })
+
+    await createMiddleware().handler(request, response, next)
+
+    expect(response.status).toHaveBeenCalledWith(401)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('should not authorize user if authentication fails', async () => {
+    request.headers.authorization = 'Bearer test'
+
+    authenticateUser.execute = jest.fn().mockReturnValue({
+      success: false,
+      failureType: 'INVALID_AUTH',
+    })
+
+    await createMiddleware().handler(request, response, next)
+
+    expect(response.status).toHaveBeenCalledWith(401)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('should not authorize user if the token is expired', async () => {
+    request.headers.authorization = 'Bearer test'
+
+    authenticateUser.execute = jest.fn().mockReturnValue({
+      success: false,
+      failureType: 'EXPIRED_TOKEN',
+    })
+
+    await createMiddleware().handler(request, response, next)
+
+    expect(response.status).toHaveBeenCalledWith(498)
+    expect(next).not.toHaveBeenCalled()
+  })
+})

--- a/src/Controller/AuthMiddleware.ts
+++ b/src/Controller/AuthMiddleware.ts
@@ -1,0 +1,78 @@
+import { NextFunction, Request, Response } from 'express'
+import { inject, injectable } from 'inversify'
+import { BaseMiddleware } from 'inversify-express-utils'
+import * as winston from 'winston'
+import TYPES from '../Bootstrap/Types'
+
+import { AuthenticateUser } from '../Domain/UseCase/AuthenticateUser'
+import { AuthenticateUserResponse } from '../Domain/UseCase/AuthenticateUserResponse'
+
+@injectable()
+export class AuthMiddleware extends BaseMiddleware {
+    private logger: winston.Logger
+
+    constructor (
+        @inject(TYPES.AuthenticateUser) private authenticateUser: AuthenticateUser,
+        @inject(TYPES.LoggerFactory) loggerFactory: () => winston.Logger,
+    ) {
+      super()
+      this.logger = loggerFactory()
+    }
+
+    async handler (request: Request, response: Response, next: NextFunction): Promise<void> {
+        const authorizationHeader = <string> request.headers.authorization
+
+        if (!authorizationHeader) {
+            this.logger.warn('Missing authentication headers')
+
+            return this.sendInvalidAuthResponse(response)
+        }
+
+        let authenticateResponse: AuthenticateUserResponse
+        try {
+            authenticateResponse = await this.authenticateUser.execute({ token: authorizationHeader.replace('Bearer ', '') })
+        } catch (error) {
+            this.logger.error('Error occurred during authentication of a user %o', error)
+
+            return this.sendInvalidAuthResponse(response)
+        }
+
+        if (!authenticateResponse.success) {
+          switch (authenticateResponse.failureType) {
+            case 'EXPIRED_TOKEN':
+              return this.sendExpiredTokenResponse(response)
+            case 'INVALID_AUTH':
+              return this.sendInvalidAuthResponse(response)
+          }
+        }
+
+        this.logger.info('Successfully authenticated user')
+
+        response.locals.user = authenticateResponse.user
+        response.locals.session = authenticateResponse.session
+
+        return next()
+    }
+
+    private sendInvalidAuthResponse(response: Response) {
+      this.logger.warn('Invalid login credentials supplied')
+
+      response.status(401).send({
+        error: {
+          tag: 'invalid-auth',
+          message: 'Invalid login credentials.',
+        },
+      })
+    }
+
+    private sendExpiredTokenResponse(response: Response) {
+      this.logger.warn('Expired token supplied')
+
+      response.status(498).send({
+        error: {
+          tag: 'expired-access-token',
+          message: 'The provided access token has expired.',
+        },
+      })
+    }
+}

--- a/src/Controller/RevisionsController.ts
+++ b/src/Controller/RevisionsController.ts
@@ -4,7 +4,7 @@ import { RevisionRepositoryInterface } from '../Domain/Revision/RevisionReposito
 import TYPES from '../Bootstrap/Types'
 import { inject } from 'inversify'
 
-@controller('/items/:item_id/revisions')
+@controller('/items/:item_id/revisions', TYPES.AuthMiddleware)
 export class RevisionsController extends BaseHttpController {
     constructor(
       @inject(TYPES.RevisionRepository) private revisionRepository: RevisionRepositoryInterface

--- a/src/Domain/Auth/AuthenticationMethod.ts
+++ b/src/Domain/Auth/AuthenticationMethod.ts
@@ -1,0 +1,9 @@
+import { Session } from '../Session/Session'
+import { User } from '../User/User'
+
+export type AuthenticationMethod = {
+  type: 'jwt' | 'session_token',
+  user: User | undefined,
+  claims?: Record<string, unknown>,
+  session?: Session
+}

--- a/src/Domain/Session/Session.ts
+++ b/src/Domain/Session/Session.ts
@@ -1,0 +1,5 @@
+export type Session = {
+  userUuid: string,
+  accessExpired: boolean,
+  refreshExpired: boolean
+}

--- a/src/Domain/Session/SessionRepositoryInterface.ts
+++ b/src/Domain/Session/SessionRepositoryInterface.ts
@@ -1,0 +1,5 @@
+import { Session } from './Session'
+
+export interface SessionRepositoryInterface {
+  findOneByToken(token: string): Promise<Session | undefined>
+}

--- a/src/Domain/UseCase/AuthenticateUser.spec.ts
+++ b/src/Domain/UseCase/AuthenticateUser.spec.ts
@@ -1,0 +1,111 @@
+import 'reflect-metadata'
+import { Session } from '../Session/Session'
+
+import { SessionRepositoryInterface } from '../Session/SessionRepositoryInterface'
+import { User } from '../User/User'
+import { UserRepositoryInterface } from '../User/UserRepositoryInterface'
+import { AuthenticateUser } from './AuthenticateUser'
+
+describe('AuthenticateUser', () => {
+  let userRepository: UserRepositoryInterface
+  let sessionRepository: SessionRepositoryInterface
+  let user: User
+  let session: Session
+
+  const createUseCase = () => new AuthenticateUser('secret', 'legacy_secret', userRepository, sessionRepository)
+
+  beforeEach(() => {
+    userRepository = {} as jest.Mocked<UserRepositoryInterface>
+    userRepository.findOneById = jest.fn()
+
+    sessionRepository = {} as jest.Mocked<SessionRepositoryInterface>
+    sessionRepository.findOneByToken = jest.fn()
+
+    user = {} as jest.Mocked<User>
+    session = {} as jest.Mocked<Session>
+  })
+
+  it('should authenticate a user based on a JWT token', async () => {
+    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlcl91dWlkIjoiMTIzIiwicHdfaGFzaCI6IjlmODZkMDgxODg0YzdkNjU5YTJmZWFhMGM1NWFkMDE1YTNiZjRmMWIyYjBiODIyY2QxNWQ2YzE1YjBmMDBhMDgiLCJpYXQiOjE1MTYyMzkwMjJ9.TXDPCbCAITDjcUUorHsF4S5Nxkz4eFE4F3TPCsKI89A'
+
+    user.encryptedPassword = 'test'
+    userRepository.findOneById = jest.fn().mockReturnValue(user)
+
+    const response = await createUseCase().execute({ token })
+
+    expect(response.success).toBeTruthy()
+  })
+
+  it('should not authenticate a user if the JWT token is inavlid', async () => {
+    const response = await createUseCase().execute({ token: 'test' })
+
+    expect(response.success).toBeFalsy()
+  })
+
+  it('should not authenticate a user if the user is from JWT token is not found', async () => {
+    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlcl91dWlkIjoiMTIzIiwicHdfaGFzaCI6IjlmODZkMDgxODg0YzdkNjU5YTJmZWFhMGM1NWFkMDE1YTNiZjRmMWIyYjBiODIyY2QxNWQ2YzE1YjBmMDBhMDgiLCJpYXQiOjE1MTYyMzkwMjJ9.TXDPCbCAITDjcUUorHsF4S5Nxkz4eFE4F3TPCsKI89A'
+
+    userRepository.findOneById = jest.fn().mockReturnValue(null)
+
+    const response = await createUseCase().execute({ token })
+
+    expect(response.success).toBeFalsy()
+  })
+
+  it('should not authenticate a user if the user from JWT token supports sessions', async () => {
+    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlcl91dWlkIjoiMTIzIiwicHdfaGFzaCI6IjlmODZkMDgxODg0YzdkNjU5YTJmZWFhMGM1NWFkMDE1YTNiZjRmMWIyYjBiODIyY2QxNWQ2YzE1YjBmMDBhMDgiLCJpYXQiOjE1MTYyMzkwMjJ9.TXDPCbCAITDjcUUorHsF4S5Nxkz4eFE4F3TPCsKI89A'
+
+    user.supportsSessions = true
+    userRepository.findOneById = jest.fn().mockReturnValue(user)
+
+    const response = await createUseCase().execute({ token })
+
+    expect(response.success).toBeFalsy()
+  })
+
+  it('should not authenticate a user if the password hash is incorrect', async () => {
+    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlcl91dWlkIjoiMTIzIiwicHdfaGFzaCI6IjlmODZkMDgxODg0YzdkNjU5YTJmZWFhMGM1NWFkMDE1YTNiZjRmMWIyYjBiODIyY2QxNWQ2YzE1YjBmMDBhMDgiLCJpYXQiOjE1MTYyMzkwMjJ9.TXDPCbCAITDjcUUorHsF4S5Nxkz4eFE4F3TPCsKI89A'
+
+    user.encryptedPassword = 'foo'
+    userRepository.findOneById = jest.fn().mockReturnValue(user)
+
+    const response = await createUseCase().execute({ token })
+
+    expect(response.success).toBeFalsy()
+  })
+
+  it('should authenticate a user from a session token', async () => {
+    sessionRepository.findOneByToken = jest.fn().mockReturnValue(session)
+
+    user.supportsSessions = true
+    userRepository.findOneById = jest.fn().mockReturnValue(user)
+
+    const response = await createUseCase().execute({ token: 'test-session-token' })
+
+    expect(response.success).toBeTruthy()
+  })
+
+  it('should not authenticate a user from a session token if session is expired', async () => {
+    session.accessExpired = true
+    sessionRepository.findOneByToken = jest.fn().mockReturnValue(session)
+
+    user.supportsSessions = true
+    userRepository.findOneById = jest.fn().mockReturnValue(user)
+
+    const response = await createUseCase().execute({ token: 'test-session-token' })
+
+    expect(response.success).toBeFalsy()
+  })
+
+  it('should not authenticate a user from a session token if refresh token is expired', async () => {
+    session.refreshExpired = true
+    sessionRepository.findOneByToken = jest.fn().mockReturnValue(session)
+
+    user.supportsSessions = true
+    userRepository.findOneById = jest.fn().mockReturnValue(user)
+
+    const response = await createUseCase().execute({ token: 'test-session-token' })
+
+    expect(response.success).toBeFalsy()
+  })
+})

--- a/src/Domain/UseCase/AuthenticateUser.ts
+++ b/src/Domain/UseCase/AuthenticateUser.ts
@@ -1,0 +1,126 @@
+import * as crypto from 'crypto'
+import { inject, injectable } from 'inversify'
+
+import { verify } from 'jsonwebtoken'
+import TYPES from '../../Bootstrap/Types'
+import { AuthenticationMethod } from '../Auth/AuthenticationMethod'
+import { Session } from '../Session/Session'
+import { SessionRepositoryInterface } from '../Session/SessionRepositoryInterface'
+import { UserRepositoryInterface } from '../User/UserRepositoryInterface'
+
+import { AuthenticateUserDTO } from './AuthenticateUserDTO'
+import { AuthenticateUserResponse } from './AuthenticateUserResponse'
+
+@injectable()
+export class AuthenticateUser {
+  constructor(
+    @inject(TYPES.JWT_SECRET) private jwtSecret: string,
+    @inject(TYPES.LEGACY_JWT_SECRET) private legacyJwtSecret: string,
+    @inject(TYPES.UserRepository) private userRepository: UserRepositoryInterface,
+    @inject(TYPES.SessionRepository) private sessionRepository: SessionRepositoryInterface,
+  ) {
+  }
+
+  async execute(dto: AuthenticateUserDTO): Promise<AuthenticateUserResponse> {
+    const authenticationMethod = await this.establishAuthenticationMethod(dto.token)
+    if (!authenticationMethod) {
+      return {
+        success: false,
+        failureType: 'INVALID_AUTH'
+      }
+    }
+
+    const user = authenticationMethod.user
+    if (!user) {
+      return {
+        success: false,
+        failureType: 'INVALID_AUTH'
+      }
+    }
+
+    if(authenticationMethod.type == 'jwt' && user.supportsSessions) {
+      return {
+        success: false,
+        failureType: 'INVALID_AUTH'
+      }
+    }
+
+    switch(authenticationMethod.type) {
+      case 'jwt': {
+        const pwHash = <string> (<Record<string, unknown>> authenticationMethod.claims).pw_hash
+        const encryptedPasswordDigest = crypto.createHash('sha256').update(user.encryptedPassword).digest('hex')
+
+        if (!pwHash || !crypto.timingSafeEqual(Buffer.from(pwHash), Buffer.from(encryptedPasswordDigest))) {
+          return {
+            success: false,
+            failureType: 'INVALID_AUTH'
+          }
+        }
+        break
+      }
+      case 'session_token': {
+        const session = <Session> authenticationMethod.session
+
+        if (session.refreshExpired) {
+          return {
+            success: false,
+            failureType: 'INVALID_AUTH'
+          }
+        }
+
+        if (session.accessExpired) {
+          return {
+            success: false,
+            failureType: 'EXPIRED_TOKEN'
+          }
+        }
+
+        break
+      }
+    }
+
+    return {
+      success: true,
+      user,
+      session: authenticationMethod.session
+    }
+  }
+
+  private decodeToken(token: string): Record<string, unknown> | undefined {
+    try {
+      return <Record<string, unknown>> verify(token, this.jwtSecret, {
+        algorithms: [ 'HS256' ]
+      })
+    } catch (error) {
+      try {
+        return <Record<string, unknown>> verify(token, this.legacyJwtSecret, {
+          algorithms: [ 'HS256' ]
+        })
+      } catch (legacyError) {
+        return undefined
+      }
+    }
+  }
+
+  private async establishAuthenticationMethod(token: string): Promise<AuthenticationMethod | undefined> {
+    const decodedToken = this.decodeToken(token)
+    if (decodedToken) {
+      return {
+        type: 'jwt',
+        user: await this.userRepository.findOneById(<string> decodedToken.user_uuid),
+        claims: decodedToken,
+      }
+    }
+
+    const session = await this.sessionRepository.findOneByToken(token)
+    if (session) {
+      return {
+        type: 'session_token',
+        user: await this.userRepository.findOneById(session.userUuid),
+        session: session,
+      }
+    }
+
+    return undefined
+  }
+}

--- a/src/Domain/UseCase/AuthenticateUserDTO.ts
+++ b/src/Domain/UseCase/AuthenticateUserDTO.ts
@@ -1,0 +1,3 @@
+export type AuthenticateUserDTO = {
+  token: string
+}

--- a/src/Domain/UseCase/AuthenticateUserResponse.ts
+++ b/src/Domain/UseCase/AuthenticateUserResponse.ts
@@ -1,0 +1,9 @@
+import { Session } from '../Session/Session'
+import { User } from '../User/User'
+
+export type AuthenticateUserResponse = {
+  success: boolean,
+  failureType?: 'INVALID_AUTH' | 'EXPIRED_TOKEN',
+  user?: User,
+  session?: Session
+}

--- a/src/Domain/User/User.ts
+++ b/src/Domain/User/User.ts
@@ -1,0 +1,4 @@
+export type User = {
+  supportsSessions: boolean,
+  encryptedPassword: string
+}

--- a/src/Domain/User/UserRepositoryInterface.ts
+++ b/src/Domain/User/UserRepositoryInterface.ts
@@ -1,0 +1,5 @@
+import { User } from './User'
+
+export interface UserRepositoryInterface {
+  findOneById(id: string): Promise<User | undefined>
+}

--- a/src/Infra/InMemory/InMemorySessionRepository.ts
+++ b/src/Infra/InMemory/InMemorySessionRepository.ts
@@ -1,0 +1,11 @@
+import { injectable } from 'inversify'
+
+import { Session } from '../../Domain/Session/Session'
+import { SessionRepositoryInterface } from '../../Domain/Session/SessionRepositoryInterface'
+
+@injectable()
+export class InMemorySessionRepository implements SessionRepositoryInterface {
+  async findOneByToken(_token: string): Promise<Session | undefined> {
+    return undefined
+  }
+}

--- a/src/Infra/InMemory/InMemoryUserRepository.ts
+++ b/src/Infra/InMemory/InMemoryUserRepository.ts
@@ -1,0 +1,14 @@
+import { injectable } from 'inversify'
+
+import { User } from '../../Domain/User/User'
+import { UserRepositoryInterface } from '../../Domain/User/UserRepositoryInterface'
+
+@injectable()
+export class InMemoryUserRepository implements UserRepositoryInterface {
+  async findOneById(_id: string): Promise<User | undefined> {
+    return {
+      supportsSessions: false,
+      encryptedPassword: 'test'
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -646,6 +646,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
+"@types/jsonwebtoken@^8.5.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz#2531d5e300803aa63279b232c014acf780c981c5"
+  integrity sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/mime@*":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"
@@ -1126,6 +1133,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
+
 buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -1548,6 +1560,13 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -3139,6 +3158,22 @@ json5@2.x, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -3148,6 +3183,23 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -3216,10 +3268,45 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
 lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -4062,7 +4149,7 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==


### PR DESCRIPTION
Add authentication layer (rewrite from Ruby syncing-server) so we can utilize JWT tokens during a reroute.

data layer is still on stubbed stage (dummy user or session returned from `InMemory...`). 