### PR TITLE
fix: auth server key must be 32 byte-long hex string

### DIFF
--- a/docker/auth.env.sample
+++ b/docker/auth.env.sample
@@ -11,6 +11,8 @@ REDIS_EVENTS_CHANNEL="auth-events"
 
 DISABLE_USER_REGISTRATION=false
 
+# Must be a hex string exactly 32 bytes long
+# e.g. feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308
 ENCRYPTION_SERVER_KEY=change-me-!
 
 PORT=3000


### PR DESCRIPTION
[ticket](https://app.asana.com/0/1199914526147392/1200284411286808/f)