### PR TITLE
fix: performance on finding ephemeral sessions

### DIFF
--- a/src/Domain/Session/EphemeralSessionRepositoryInterface.ts
+++ b/src/Domain/Session/EphemeralSessionRepositoryInterface.ts
@@ -4,6 +4,6 @@ export interface EphemeralSessionRepositoryInterface {
   findOneByUuid(uuid: string): Promise<EphemeralSession | undefined>
   findAllByUserUuid(userUuid: string): Promise<Array<EphemeralSession>>
   updateTokensAndExpirationDates(uuid: string, hashedAccessToken: string, hashedRefreshToken: string, accessExpiration: Date, refreshExpiration: Date): Promise<void>
-  deleteOneByUuid(uuid: string): Promise<void>
+  deleteOne(uuid: string, userUuid: string): Promise<void>
   save(ephemeralSession: EphemeralSession): Promise<void>
 }

--- a/src/Domain/Session/SessionService.spec.ts
+++ b/src/Domain/Session/SessionService.spec.ts
@@ -55,7 +55,7 @@ describe('SessionService', () => {
     ephemeralSessionRepository.save = jest.fn()
     ephemeralSessionRepository.findOneByUuid = jest.fn()
     ephemeralSessionRepository.updateTokensAndExpirationDates = jest.fn()
-    ephemeralSessionRepository.deleteOneByUuid = jest.fn()
+    ephemeralSessionRepository.deleteOne = jest.fn()
 
     revokedSessionRepository = {} as jest.Mocked<RevokedSessionRepositoryInterface>
     revokedSessionRepository.save = jest.fn()
@@ -178,7 +178,7 @@ describe('SessionService', () => {
     await createService().deleteSessionByToken('1:2:3')
 
     expect(sessionRepository.deleteOneByUuid).toHaveBeenCalledWith('2e1e43')
-    expect(ephemeralSessionRepository.deleteOneByUuid).toHaveBeenCalledWith('2e1e43')
+    expect(ephemeralSessionRepository.deleteOne).toHaveBeenCalledWith('2e1e43', '1-2-3')
   })
 
   it('should not delete a session by token if session is not found', async () => {
@@ -193,7 +193,7 @@ describe('SessionService', () => {
     await createService().deleteSessionByToken('1:4:3')
 
     expect(sessionRepository.deleteOneByUuid).not.toHaveBeenCalled()
-    expect(ephemeralSessionRepository.deleteOneByUuid).not.toHaveBeenCalled()
+    expect(ephemeralSessionRepository.deleteOne).not.toHaveBeenCalled()
   })
 
   it('should determine if a refresh token is valid', async () => {

--- a/src/Domain/Session/SessionService.ts
+++ b/src/Domain/Session/SessionService.ts
@@ -165,7 +165,7 @@ export class SessionService implements SessionServiceInterace {
 
     if (session) {
       await this.sessionRepository.deleteOneByUuid(session.uuid)
-      await this.ephemeralSessionRepository.deleteOneByUuid(session.uuid)
+      await this.ephemeralSessionRepository.deleteOne(session.uuid, session.userUuid)
     }
   }
 


### PR DESCRIPTION
Upon sync Redis was scanned too many times for an ephemeral session. Replaced with a different approach to Redis save/read which should be more optimal performance-wise.