### PR TITLE
feat: add internal endpoint to remove MFA Extension Item

### DIFF
--- a/src/Controller/ItemsController.spec.ts
+++ b/src/Controller/ItemsController.spec.ts
@@ -262,4 +262,35 @@ describe('ItemsController', () => {
     expect(result.statusCode).toEqual(200)
     expect(await result.content.readAsStringAsync()).toEqual('{"secret":"foo","extensionUuid":"e-1-2-3"}')
   })
+
+  it('should not delete mfa secret if one does not exist', async () => {
+    request.body = {}
+    request.params = {
+      userUuid: '1-2-3',
+    }
+
+    const httpResponse = <results.NotFoundResult> await createController().removeMFASecret(request)
+    const result = await httpResponse.executeAsync()
+
+    expect(result.statusCode).toEqual(404)
+  })
+
+  it('should delete mfa secret by user uuid', async () => {
+    request.body = {}
+    request.params = {
+      userUuid: '1-2-3',
+    }
+
+    const extension = {
+      uuid: 'e-1-2-3',
+    } as jest.Mocked<Item>
+    itemRepository.findMFAExtensionByUserUuid = jest.fn().mockReturnValue(extension)
+    itemRepository.remove = jest.fn()
+
+    const httpResponse = <results.OkResult> await createController().removeMFASecret(request)
+    const result = await httpResponse.executeAsync()
+
+    expect(result.statusCode).toEqual(200)
+    expect(itemRepository.remove).toHaveBeenCalledWith(extension)
+  })
 })

--- a/src/Controller/ItemsController.ts
+++ b/src/Controller/ItemsController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import { inject } from 'inversify'
-import { BaseHttpController, controller, httpGet, httpPost, results } from 'inversify-express-utils'
+import { BaseHttpController, controller, httpDelete, httpGet, httpPost, results } from 'inversify-express-utils'
 import { Logger } from 'winston'
 import TYPES from '../Bootstrap/Types'
 import { ApiVersion } from '../Domain/Api/ApiVersion'
@@ -79,5 +79,17 @@ export class ItemsController extends BaseHttpController {
       secret: mfaContent.secret,
       extensionUuid: mfaExtension.uuid,
     })
+  }
+
+  @httpDelete('/mfa/:userUuid')
+  public async removeMFASecret(request: Request): Promise<results.NotFoundResult | results.OkResult> {
+    const mfaExtension = await this.itemRepository.findMFAExtensionByUserUuid(request.params.userUuid)
+    if (mfaExtension === undefined) {
+      return this.notFound()
+    }
+
+    await this.itemRepository.remove(mfaExtension)
+
+    return this.ok()
   }
 }


### PR DESCRIPTION
This is an internal-only endpoint which will be utilized by Auth Service to remove the MFA Item in order for us to migrate users gradually to UserSettings. The endpoint will be called when a user disables MFA - Auth will cleanup it up as an item and will persist only the UserSettings from that point if re-enabled.