### PR TITLE
fix: transfer limit breached - cursor token stuck issue

### DIFF
--- a/src/Domain/Item/ItemService.spec.ts
+++ b/src/Domain/Item/ItemService.spec.ts
@@ -243,8 +243,7 @@ describe('ItemService', () => {
     })
   })
 
-  it('should retrieve at least one item if it breaches the data transfer limit', async () => {
-    itemRepository.findAll = jest.fn().mockReturnValue([ item1 ])
+  it('should retrieve at least two items if the first one breaches the data transfer limit to prevent cursor token being stuck on first item', async () => {
     itemRepository.findContentSizeForComputingTransferLimit = jest.fn().mockReturnValue([
       {
         uuid: item1.uuid,
@@ -263,12 +262,12 @@ describe('ItemService', () => {
         contentType: ContentType.Note,
       })
     ).toEqual({
-      items: [ item1 ],
+      items: [ item1, item2 ],
     })
 
     expect(logger.warn).toHaveBeenCalled()
     expect(itemRepository.findAll).toHaveBeenCalledWith({
-      uuids: [ '1-2-3' ],
+      uuids: [ '1-2-3', '2-3-4' ],
       sortBy: 'updated_at_timestamp',
       sortOrder: 'ASC',
     })

--- a/src/Domain/Item/ItemService.ts
+++ b/src/Domain/Item/ItemService.ts
@@ -362,14 +362,15 @@ export class ItemService implements ItemServiceInterface {
       itemUuidsToFetch.push(itemContentSize.uuid)
       totalContentSizeInBytes += contentSize
 
-      if (totalContentSizeInBytes >= this.contentSizeTransferLimit) {
+      const transferLimitBreached = totalContentSizeInBytes >= this.contentSizeTransferLimit
+      const transferLimitBreachedAtFirstItem = transferLimitBreached && itemUuidsToFetch.length === 1 && itemContentSizes.length > 1
+      if (transferLimitBreachedAtFirstItem) {
+        this.logger.warn(`Item ${itemUuidsToFetch[0]} is breaching the content size transfer limit: ${this.contentSizeTransferLimit}`)
+      }
+
+      if (transferLimitBreached && !transferLimitBreachedAtFirstItem) {
         break
       }
-    }
-
-    const singleItemIsBiggerThanTheContentSizeTransferLimit = itemUuidsToFetch.length === 1 && itemContentSizes.length > 1
-    if (singleItemIsBiggerThanTheContentSizeTransferLimit) {
-      this.logger.warn(`Item ${itemUuidsToFetch[0]} is breaching the content size transfer limit: ${this.contentSizeTransferLimit}`)
     }
 
     return itemUuidsToFetch


### PR DESCRIPTION
When only one item was returned due to breaching the transfer limit the response contained a cursor token for pagination.

When a subsequent request was made it tried to fetch items `updatedAtTimestamp >= cursorToken` - thus it was stuck in a loop of retrieving the first item breaching the transfer limit. 

I didn't want to change the comparison from `>=` to `>` when using the cursor token so the only way is to add another item over the breaching limit. 