### PR TITLE
fix: remove server extensions from computing integrity hash

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Description
+
+<!--- your description here -->
+
+## Related Issue(s)
+
+<!--- link(s) to the issue(s) -->

--- a/src/Infra/MySQL/MySQLItemRepository.spec.ts
+++ b/src/Infra/MySQL/MySQLItemRepository.spec.ts
@@ -278,6 +278,7 @@ describe('MySQLItemRepository', () => {
     queryBuilder.getRawMany = jest.fn().mockReturnValue([
       { updated_at_timestamp: 1616164633241312, content_type: ContentType.Note },
       { updated_at_timestamp: 1616164633242313, content_type: null },
+      { updated_at_timestamp: 1616164633242313, content_type: ContentType.Mfa },
       { updated_at_timestamp: 1616164633242313, content_type: ContentType.ServerExtension },
     ])
     queryBuilder.select = jest.fn()
@@ -294,7 +295,7 @@ describe('MySQLItemRepository', () => {
     expect(queryBuilder.andWhere).toHaveBeenNthCalledWith(1, 'item.deleted = :deleted', { deleted: false })
 
     expect(result.length).toEqual(2)
-    expect(result[0]).toEqual({ content_type: 'SF|Extension', updated_at_timestamp: 1616164633242313 })
+    expect(result[0]).toEqual({ content_type: 'SF|MFA', updated_at_timestamp: 1616164633242313 })
     expect(result[1]).toEqual({ content_type: 'Note', updated_at_timestamp: 1616164633241312 })
   })
 

--- a/src/Infra/MySQL/MySQLItemRepository.ts
+++ b/src/Infra/MySQL/MySQLItemRepository.ts
@@ -4,6 +4,7 @@ import { Item } from '../../Domain/Item/Item'
 import { ItemQuery } from '../../Domain/Item/ItemQuery'
 import { ItemRepositoryInterface } from '../../Domain/Item/ItemRepositoryInterface'
 import { ReadStream } from 'fs'
+import { ContentType } from '@standardnotes/common'
 
 @injectable()
 @EntityRepository(Item)
@@ -62,7 +63,7 @@ export class MySQLItemRepository extends Repository<Item> implements ItemReposit
     const items = await queryBuilder.getRawMany()
 
     return items
-      .filter(item => item.content_type !== null)
+      .filter(item => item.content_type !== null && item.content_type !== ContentType.ServerExtension)
       .sort((itemA, itemB) => itemB.updated_at_timestamp - itemA.updated_at_timestamp)
   }
 


### PR DESCRIPTION
## Description

Removes server extension items from integrity hash calculation. This is a preparation step for moving CloudLink backup settings into Auth's Settings model.

## Related Issue(s)

https://app.asana.com/0/0/1201547828356719/f