### PR TITLE
feat: split backup emails into multiple parts for large sets

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@standardnotes/analytics": "^1.0.1",
     "@standardnotes/auth": "3.17.10",
     "@standardnotes/common": "1.17.0",
-    "@standardnotes/domain-events": "2.23.14",
+    "@standardnotes/domain-events": "^2.26.11",
     "@standardnotes/domain-events-infra": "1.4.51",
     "@standardnotes/payloads": "^1.4.18",
     "@standardnotes/responses": "^1.4.1",

--- a/src/Bootstrap/Container.ts
+++ b/src/Bootstrap/Container.ts
@@ -58,6 +58,8 @@ import { EmailBackupRequestedEventHandler } from '../Domain/Handler/EmailBackupR
 import { CloudBackupRequestedEventHandler } from '../Domain/Handler/CloudBackupRequestedEventHandler'
 import { CheckIntegrity } from '../Domain/UseCase/CheckIntegrity/CheckIntegrity'
 import { GetItem } from '../Domain/UseCase/GetItem/GetItem'
+import { ItemTransferCalculatorInterface } from '../Domain/Item/ItemTransferCalculatorInterface'
+import { ItemTransferCalculator } from '../Domain/Item/ItemTransferCalculator'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const newrelicWinstonEnricher = require('@newrelic/winston-enricher')
@@ -295,6 +297,8 @@ export class ContainerConfigLoader {
         container.get(TYPES.ContentFilter),
       ])
     )
+
+    container.bind<ItemTransferCalculatorInterface>(TYPES.ItemTransferCalculator).to(ItemTransferCalculator)
 
     return container
   }

--- a/src/Bootstrap/Types.ts
+++ b/src/Bootstrap/Types.ts
@@ -68,6 +68,7 @@ const TYPES = {
   ContentFilter: Symbol.for('ContentFilter'),
   ItemFactory: Symbol.for('ItemFactory'),
   AnalyticsStore: Symbol.for('AnalyticsStore'),
+  ItemTransferCalculator: Symbol.for('ItemTransferCalculator'),
 }
 
 export default TYPES

--- a/src/Domain/Event/DomainEventFactory.spec.ts
+++ b/src/Domain/Event/DomainEventFactory.spec.ts
@@ -160,7 +160,12 @@ describe('DomainEventFactory', () => {
   })
 
   it('should create a EMAIL_BACKUP_ATTACHMENT_CREATED event', () => {
-    expect(createFactory().createEmailBackupAttachmentCreatedEvent('backup-file', 'test@test.com'))
+    expect(createFactory().createEmailBackupAttachmentCreatedEvent({
+      backupFileName: 'backup-file',
+      email: 'test@test.com',
+      backupFileIndex: 1,
+      backupFilesTotal: 2,
+    }))
       .toEqual({
         createdAt: expect.any(Date),
         meta: {
@@ -172,6 +177,8 @@ describe('DomainEventFactory', () => {
         payload: {
           backupFileName: 'backup-file',
           email: 'test@test.com',
+          backupFileIndex: 1,
+          backupFilesTotal: 2,
         },
         type: 'EMAIL_BACKUP_ATTACHMENT_CREATED',
       })

--- a/src/Domain/Event/DomainEventFactory.ts
+++ b/src/Domain/Event/DomainEventFactory.ts
@@ -154,20 +154,22 @@ export class DomainEventFactory implements DomainEventFactoryInterface {
     }
   }
 
-  createEmailBackupAttachmentCreatedEvent(backupFileName: string, email: string): EmailBackupAttachmentCreatedEvent {
+  createEmailBackupAttachmentCreatedEvent(dto: {
+    backupFileName: string,
+    backupFileIndex: number,
+    backupFilesTotal: number,
+    email: string,
+  }): EmailBackupAttachmentCreatedEvent {
     return {
       type: 'EMAIL_BACKUP_ATTACHMENT_CREATED',
       createdAt: this.timer.getUTCDate(),
       meta: {
         correlation: {
-          userIdentifier: email,
+          userIdentifier: dto.email,
           userIdentifierType: 'email',
         },
       },
-      payload: {
-        backupFileName,
-        email,
-      },
+      payload: dto,
     }
   }
 }

--- a/src/Domain/Event/DomainEventFactoryInterface.ts
+++ b/src/Domain/Event/DomainEventFactoryInterface.ts
@@ -16,6 +16,11 @@ export interface DomainEventFactoryInterface {
     source: 'account-deletion' | 'realtime-extensions-sync'
   }): ItemsSyncedEvent
   createEmailArchiveExtensionSyncedEvent(userUuid: string, extensionId: string): EmailArchiveExtensionSyncedEvent
-  createEmailBackupAttachmentCreatedEvent(backupFileName: string, email: string): EmailBackupAttachmentCreatedEvent
+  createEmailBackupAttachmentCreatedEvent(dto: {
+    backupFileName: string,
+    backupFileIndex: number,
+    backupFilesTotal: number,
+    email: string,
+  }): EmailBackupAttachmentCreatedEvent
   createDuplicateItemSyncedEvent(itemUuid: string, userUuid: string): DuplicateItemSyncedEvent
 }

--- a/src/Domain/Handler/EmailBackupRequestedEventHandler.spec.ts
+++ b/src/Domain/Handler/EmailBackupRequestedEventHandler.spec.ts
@@ -8,6 +8,7 @@ import { Item } from '../Item/Item'
 import { ItemBackupServiceInterface } from '../Item/ItemBackupServiceInterface'
 import { ItemRepositoryInterface } from '../Item/ItemRepositoryInterface'
 import { EmailBackupRequestedEventHandler } from './EmailBackupRequestedEventHandler'
+import { ItemTransferCalculatorInterface } from '../Item/ItemTransferCalculatorInterface'
 
 describe('EmailBackupRequestedEventHandler', () => {
   let itemRepository: ItemRepositoryInterface
@@ -16,6 +17,7 @@ describe('EmailBackupRequestedEventHandler', () => {
   let domainEventPublisher: DomainEventPublisherInterface
   let domainEventFactory: DomainEventFactoryInterface
   const emailAttachmentMaxByteSize = 100
+  let itemTransferCalculator: ItemTransferCalculatorInterface
   let item: Item
   let event: EmailBackupRequestedEvent
   let logger: Logger
@@ -27,6 +29,7 @@ describe('EmailBackupRequestedEventHandler', () => {
     domainEventPublisher,
     domainEventFactory,
     emailAttachmentMaxByteSize,
+    itemTransferCalculator,
     logger
   )
 
@@ -57,6 +60,11 @@ describe('EmailBackupRequestedEventHandler', () => {
     domainEventFactory.createEmailBackupAttachmentCreatedEvent = jest.fn().mockReturnValue({} as jest.Mocked<EmailBackupAttachmentCreatedEvent>)
     domainEventFactory.createMailBackupAttachmentTooBigEvent = jest.fn().mockReturnValue({} as jest.Mocked<MailBackupAttachmentTooBigEvent>)
 
+    itemTransferCalculator = {} as jest.Mocked<ItemTransferCalculatorInterface>
+    itemTransferCalculator.computeItemUuidBundlesToFetch = jest.fn().mockReturnValue([
+      ['1-2-3'],
+    ])
+
     logger = {} as jest.Mocked<Logger>
     logger.debug = jest.fn()
     logger.warn = jest.fn()
@@ -66,7 +74,38 @@ describe('EmailBackupRequestedEventHandler', () => {
     await createHandler().handle(event)
 
     expect(domainEventPublisher.publish).toHaveBeenCalledTimes(1)
-    expect(domainEventFactory.createEmailBackupAttachmentCreatedEvent).toHaveBeenCalledWith('backup-file-name', 'test@test.com')
+    expect(domainEventFactory.createEmailBackupAttachmentCreatedEvent).toHaveBeenCalledWith({
+      backupFileIndex: 1,
+      backupFileName: 'backup-file-name',
+      backupFilesTotal: 1,
+      email: 'test@test.com',
+    })
+  })
+
+  it('should inform that multipart backup attachment for email was created', async () => {
+    itemBackupService.backup = jest.fn()
+      .mockReturnValueOnce('backup-file-name-1')
+      .mockReturnValueOnce('backup-file-name-2')
+    itemTransferCalculator.computeItemUuidBundlesToFetch = jest.fn().mockReturnValue([
+      ['1-2-3'],
+      ['2-3-4'],
+    ])
+
+    await createHandler().handle(event)
+
+    expect(domainEventPublisher.publish).toHaveBeenCalledTimes(2)
+    expect(domainEventFactory.createEmailBackupAttachmentCreatedEvent).toHaveBeenNthCalledWith(1, {
+      backupFileIndex: 1,
+      backupFileName: 'backup-file-name-1',
+      backupFilesTotal: 2,
+      email: 'test@test.com',
+    })
+    expect(domainEventFactory.createEmailBackupAttachmentCreatedEvent).toHaveBeenNthCalledWith(2, {
+      backupFileIndex: 2,
+      backupFileName: 'backup-file-name-2',
+      backupFilesTotal: 2,
+      email: 'test@test.com',
+    })
   })
 
   it('should not inform that backup attachment for email was created if user key params cannot be obtained', async () => {
@@ -86,38 +125,6 @@ describe('EmailBackupRequestedEventHandler', () => {
     await createHandler().handle(event)
 
     expect(domainEventPublisher.publish).not.toHaveBeenCalled()
-    expect(domainEventFactory.createEmailBackupAttachmentCreatedEvent).not.toHaveBeenCalled()
-  })
-
-  it('should inform that backup attachment for email was too big', async () => {
-    item = {
-      content: 'This content is too large so should not be sent',
-    } as jest.Mocked<Item>
-    itemRepository.findAll = jest.fn().mockReturnValue([ item ])
-
-    await createHandler().handle(event)
-
-    expect(domainEventPublisher.publish).toHaveBeenCalledTimes(1)
-    expect(domainEventFactory.createMailBackupAttachmentTooBigEvent).toHaveBeenCalledWith({
-      allowedSize: '100',
-      attachmentSize: '118',
-      email: 'test@test.com',
-      muteEmailsSettingUuid: '1-2-3',
-    })
-    expect(domainEventFactory.createEmailBackupAttachmentCreatedEvent).not.toHaveBeenCalled()
-  })
-
-  it('should not inform that backup attachment for email was too big if mail notifications are muted', async () => {
-    event.payload.userHasEmailsMuted = true
-    item = {
-      content: 'This content is too large so should not be sent',
-    } as jest.Mocked<Item>
-    itemRepository.findAll = jest.fn().mockReturnValue([ item ])
-
-    await createHandler().handle(event)
-
-    expect(domainEventPublisher.publish).not.toHaveBeenCalled()
-    expect(domainEventFactory.createMailBackupAttachmentTooBigEvent).not.toHaveBeenCalled()
     expect(domainEventFactory.createEmailBackupAttachmentCreatedEvent).not.toHaveBeenCalled()
   })
 })

--- a/src/Domain/Handler/EmailBackupRequestedEventHandler.ts
+++ b/src/Domain/Handler/EmailBackupRequestedEventHandler.ts
@@ -7,6 +7,8 @@ import { AuthHttpServiceInterface } from '../Auth/AuthHttpServiceInterface'
 import { DomainEventFactoryInterface } from '../Event/DomainEventFactoryInterface'
 import { ItemBackupServiceInterface } from '../Item/ItemBackupServiceInterface'
 import { ItemRepositoryInterface } from '../Item/ItemRepositoryInterface'
+import { ItemTransferCalculatorInterface } from '../Item/ItemTransferCalculatorInterface'
+import { ItemQuery } from '../Item/ItemQuery'
 
 @injectable()
 export class EmailBackupRequestedEventHandler implements DomainEventHandlerInterface {
@@ -17,18 +19,12 @@ export class EmailBackupRequestedEventHandler implements DomainEventHandlerInter
     @inject(TYPES.DomainEventPublisher) private domainEventPublisher: DomainEventPublisherInterface,
     @inject(TYPES.DomainEventFactory) private domainEventFactory: DomainEventFactoryInterface,
     @inject(TYPES.EMAIL_ATTACHMENT_MAX_BYTE_SIZE) private emailAttachmentMaxByteSize: number,
+    @inject(TYPES.ItemTransferCalculator) private itemTransferCalculator: ItemTransferCalculatorInterface,
     @inject(TYPES.Logger) private logger: Logger,
   ) {
   }
 
   async handle(event: EmailBackupRequestedEvent): Promise<void> {
-    const items = await this.itemRepository.findAll({
-      userUuid: event.payload.userUuid,
-      sortBy: 'updated_at_timestamp',
-      sortOrder: 'ASC',
-      deleted: false,
-    })
-
     let authParams: KeyParamsData
     try {
       authParams = await this.authHttpService.getUserKeyParams({
@@ -41,41 +37,38 @@ export class EmailBackupRequestedEventHandler implements DomainEventHandlerInter
       return
     }
 
-    const data = JSON.stringify({
-      items,
-      auth_params: authParams,
-    })
-
-    if (data.length > this.emailAttachmentMaxByteSize) {
-      this.logger.debug(`Backup email attachment too big: ${data.length}`)
-      if (event.payload.userHasEmailsMuted) {
-        return
-      }
-
-      this.logger.debug('Publishing MAIL_BACKUP_ATTACHMENT_TOO_BIG event')
-
-      await this.domainEventPublisher.publish(
-        this.domainEventFactory.createMailBackupAttachmentTooBigEvent({
-          allowedSize: `${this.emailAttachmentMaxByteSize}`,
-          attachmentSize: `${data.length}`,
-          email: authParams.identifier as string,
-          muteEmailsSettingUuid: event.payload.muteEmailsSettingUuid,
-        })
-      )
-
-      return
+    const itemQuery: ItemQuery = {
+      userUuid: event.payload.userUuid,
+      sortBy: 'updated_at_timestamp',
+      sortOrder: 'ASC',
+      deleted: false,
     }
+    const itemUuidBundles = await this.itemTransferCalculator.computeItemUuidBundlesToFetch(itemQuery, this.emailAttachmentMaxByteSize)
 
-    const backupFileName = await this.itemBackupService.backup(items, authParams)
+    let bundleIndex = 1
+    for (const itemUuidBundle of itemUuidBundles) {
+      const items = await this.itemRepository.findAll({
+        uuids: itemUuidBundle,
+        sortBy: 'updated_at_timestamp',
+        sortOrder: 'ASC',
+      })
 
-    this.logger.debug(`Data backed up into: ${backupFileName}`)
+      const backupFileName = await this.itemBackupService.backup(items, authParams)
 
-    if (backupFileName.length !== 0) {
-      this.logger.debug('Publishing EMAIL_BACKUP_ATTACHMENT_CREATED event')
+      this.logger.debug(`Data backed up into: ${backupFileName}`)
 
-      await this.domainEventPublisher.publish(
-        this.domainEventFactory.createEmailBackupAttachmentCreatedEvent(backupFileName, authParams.identifier as string)
-      )
+      if (backupFileName.length !== 0) {
+        this.logger.debug('Publishing EMAIL_BACKUP_ATTACHMENT_CREATED event')
+
+        await this.domainEventPublisher.publish(
+          this.domainEventFactory.createEmailBackupAttachmentCreatedEvent({
+            backupFileName,
+            backupFileIndex: bundleIndex++,
+            backupFilesTotal: itemUuidBundles.length,
+            email: authParams.identifier as string,
+          })
+        )
+      }
     }
   }
 }

--- a/src/Domain/Item/ItemTransferCalculator.spec.ts
+++ b/src/Domain/Item/ItemTransferCalculator.spec.ts
@@ -1,0 +1,211 @@
+import 'reflect-metadata'
+
+import { Logger } from 'winston'
+import { ItemQuery } from './ItemQuery'
+
+import { ItemRepositoryInterface } from './ItemRepositoryInterface'
+
+import { ItemTransferCalculator } from './ItemTransferCalculator'
+
+describe('ItemTransferCalculator', () => {
+  let itemRepository: ItemRepositoryInterface
+  let logger: Logger
+
+  const createCalculator = () => new ItemTransferCalculator(itemRepository, logger)
+
+  beforeEach(() => {
+    itemRepository = {} as jest.Mocked<ItemRepositoryInterface>
+    itemRepository.findContentSizeForComputingTransferLimit = jest.fn().mockReturnValue([])
+
+    logger = {} as jest.Mocked<Logger>
+    logger.warn = jest.fn()
+  })
+
+  describe('fetching uuids', () => {
+    it('should compute uuids to fetch based on transfer limit - one item overlaping limit', async () => {
+      const query = {} as jest.Mocked<ItemQuery>
+      itemRepository.findContentSizeForComputingTransferLimit = jest.fn().mockReturnValue([
+        {
+          uuid: '1-2-3',
+          contentSize: 20,
+        },
+        {
+          uuid: '2-3-4',
+          contentSize: 20,
+        },
+        {
+          uuid: '3-4-5',
+          contentSize: 20,
+        },
+      ])
+
+      const result = await createCalculator().computeItemUuidsToFetch(query, 50)
+
+      expect(result).toEqual(['1-2-3', '2-3-4', '3-4-5'])
+    })
+
+    it('should compute uuids to fetch based on transfer limit - exact limit fit', async () => {
+      const query = {} as jest.Mocked<ItemQuery>
+      itemRepository.findContentSizeForComputingTransferLimit = jest.fn().mockReturnValue([
+        {
+          uuid: '1-2-3',
+          contentSize: 20,
+        },
+        {
+          uuid: '2-3-4',
+          contentSize: 20,
+        },
+        {
+          uuid: '3-4-5',
+          contentSize: 20,
+        },
+      ])
+
+      const result = await createCalculator().computeItemUuidsToFetch(query, 40)
+
+      expect(result).toEqual(['1-2-3', '2-3-4'])
+    })
+
+    it('should compute uuids to fetch based on transfer limit - content size not defined on an item', async () => {
+      const query = {} as jest.Mocked<ItemQuery>
+      itemRepository.findContentSizeForComputingTransferLimit = jest.fn().mockReturnValue([
+        {
+          uuid: '1-2-3',
+          contentSize: 20,
+        },
+        {
+          uuid: '2-3-4',
+          contentSize: 20,
+        },
+        {
+          uuid: '3-4-5',
+        },
+      ])
+
+      const result = await createCalculator().computeItemUuidsToFetch(query, 50)
+
+      expect(result).toEqual(['1-2-3', '2-3-4', '3-4-5'])
+    })
+
+    it('should compute uuids to fetch based on transfer limit - first item over the limit', async () => {
+      const query = {} as jest.Mocked<ItemQuery>
+      itemRepository.findContentSizeForComputingTransferLimit = jest.fn().mockReturnValue([
+        {
+          uuid: '1-2-3',
+          contentSize: 50,
+        },
+        {
+          uuid: '2-3-4',
+          contentSize: 20,
+        },
+        {
+          uuid: '3-4-5',
+          contentSize: 20,
+        },
+      ])
+
+      const result = await createCalculator().computeItemUuidsToFetch(query, 40)
+
+      expect(result).toEqual(['1-2-3', '2-3-4'])
+    })
+  })
+
+  describe('fetching bundles', () => {
+    it('should compute uuid bundles to fetch based on transfer limit - one item overlaping limit', async () => {
+      const query = {} as jest.Mocked<ItemQuery>
+      itemRepository.findContentSizeForComputingTransferLimit = jest.fn().mockReturnValue([
+        {
+          uuid: '1-2-3',
+          contentSize: 20,
+        },
+        {
+          uuid: '2-3-4',
+          contentSize: 20,
+        },
+        {
+          uuid: '3-4-5',
+          contentSize: 20,
+        },
+      ])
+
+      const result = await createCalculator().computeItemUuidBundlesToFetch(query, 50)
+
+      expect(result).toEqual([
+        ['1-2-3', '2-3-4', '3-4-5'],
+      ])
+    })
+
+    it('should compute uuid bundles to fetch based on transfer limit - exact limit fit', async () => {
+      const query = {} as jest.Mocked<ItemQuery>
+      itemRepository.findContentSizeForComputingTransferLimit = jest.fn().mockReturnValue([
+        {
+          uuid: '1-2-3',
+          contentSize: 20,
+        },
+        {
+          uuid: '2-3-4',
+          contentSize: 20,
+        },
+        {
+          uuid: '3-4-5',
+          contentSize: 20,
+        },
+      ])
+
+      const result = await createCalculator().computeItemUuidBundlesToFetch(query, 40)
+
+      expect(result).toEqual([
+        ['1-2-3', '2-3-4'],
+        ['3-4-5'],
+      ])
+    })
+
+    it('should compute uuid bundles to fetch based on transfer limit - content size not defined on an item', async () => {
+      const query = {} as jest.Mocked<ItemQuery>
+      itemRepository.findContentSizeForComputingTransferLimit = jest.fn().mockReturnValue([
+        {
+          uuid: '1-2-3',
+          contentSize: 20,
+        },
+        {
+          uuid: '2-3-4',
+          contentSize: 20,
+        },
+        {
+          uuid: '3-4-5',
+        },
+      ])
+
+      const result = await createCalculator().computeItemUuidBundlesToFetch(query, 50)
+
+      expect(result).toEqual([
+        ['1-2-3', '2-3-4', '3-4-5'],
+      ])
+    })
+
+    it('should compute uuid bundles to fetch based on transfer limit - first item over the limit', async () => {
+      const query = {} as jest.Mocked<ItemQuery>
+      itemRepository.findContentSizeForComputingTransferLimit = jest.fn().mockReturnValue([
+        {
+          uuid: '1-2-3',
+          contentSize: 50,
+        },
+        {
+          uuid: '2-3-4',
+          contentSize: 20,
+        },
+        {
+          uuid: '3-4-5',
+          contentSize: 20,
+        },
+      ])
+
+      const result = await createCalculator().computeItemUuidBundlesToFetch(query, 40)
+
+      expect(result).toEqual([
+        ['1-2-3', '2-3-4'],
+        ['3-4-5'],
+      ])
+    })
+  })
+})

--- a/src/Domain/Item/ItemTransferCalculator.ts
+++ b/src/Domain/Item/ItemTransferCalculator.ts
@@ -1,0 +1,91 @@
+import { inject, injectable } from 'inversify'
+import { Uuid } from '@standardnotes/common'
+import { Logger } from 'winston'
+
+import TYPES from '../../Bootstrap/Types'
+
+import { ItemTransferCalculatorInterface } from './ItemTransferCalculatorInterface'
+import { ItemQuery } from './ItemQuery'
+import { ItemRepositoryInterface } from './ItemRepositoryInterface'
+
+@injectable()
+export class ItemTransferCalculator implements ItemTransferCalculatorInterface {
+  constructor(
+    @inject(TYPES.ItemRepository) private itemRepository: ItemRepositoryInterface,
+    @inject(TYPES.Logger) private logger: Logger
+  ) {
+  }
+
+  async computeItemUuidsToFetch(itemQuery: ItemQuery, bytesTransferLimit: number): Promise<Array<Uuid>> {
+    const itemUuidsToFetch = []
+    const itemContentSizes = await this.itemRepository.findContentSizeForComputingTransferLimit(itemQuery)
+    let totalContentSizeInBytes = 0
+    for (const itemContentSize of itemContentSizes) {
+      const contentSize = itemContentSize.contentSize ?? 0
+
+      itemUuidsToFetch.push(itemContentSize.uuid)
+      totalContentSizeInBytes += contentSize
+
+      const transferLimitBreached = this.isTransferLimitBreached({
+        totalContentSizeInBytes,
+        bytesTransferLimit,
+        itemUuidsToFetch,
+        itemContentSizes,
+      })
+
+      if (transferLimitBreached) {
+        break
+      }
+    }
+
+    return itemUuidsToFetch
+  }
+
+  async computeItemUuidBundlesToFetch(itemQuery: ItemQuery, bytesTransferLimit: number): Promise<Array<Array<Uuid>>> {
+    let itemUuidsToFetch = []
+    const itemContentSizes = await this.itemRepository.findContentSizeForComputingTransferLimit(itemQuery)
+    let totalContentSizeInBytes = 0
+    const bundles = []
+    for (const itemContentSize of itemContentSizes) {
+      const contentSize = itemContentSize.contentSize ?? 0
+
+      itemUuidsToFetch.push(itemContentSize.uuid)
+      totalContentSizeInBytes += contentSize
+
+      const transferLimitBreached = this.isTransferLimitBreached({
+        totalContentSizeInBytes,
+        bytesTransferLimit,
+        itemUuidsToFetch,
+        itemContentSizes,
+      })
+
+      if (transferLimitBreached) {
+        bundles.push(Object.assign([], itemUuidsToFetch))
+        totalContentSizeInBytes = 0
+        itemUuidsToFetch = []
+      }
+    }
+
+    if (itemUuidsToFetch.length > 0) {
+      bundles.push(itemUuidsToFetch)
+    }
+
+    return bundles
+  }
+
+  private isTransferLimitBreached(dto: {
+    totalContentSizeInBytes: number,
+    bytesTransferLimit: number,
+    itemUuidsToFetch: Array<Uuid>,
+    itemContentSizes: Array<{ uuid: string, contentSize: number | null }>,
+  }): boolean {
+    const transferLimitBreached = dto.totalContentSizeInBytes >= dto.bytesTransferLimit
+    const transferLimitBreachedAtFirstItem = transferLimitBreached && dto.itemUuidsToFetch.length === 1 && dto.itemContentSizes.length > 1
+
+    if (transferLimitBreachedAtFirstItem) {
+      this.logger.warn(`Item ${dto.itemUuidsToFetch[0]} is breaching the content size transfer limit: ${dto.bytesTransferLimit}`)
+    }
+
+    return transferLimitBreached && !transferLimitBreachedAtFirstItem
+  }
+}

--- a/src/Domain/Item/ItemTransferCalculatorInterface.ts
+++ b/src/Domain/Item/ItemTransferCalculatorInterface.ts
@@ -1,0 +1,8 @@
+import { Uuid } from '@standardnotes/common'
+
+import { ItemQuery } from './ItemQuery'
+
+export interface ItemTransferCalculatorInterface {
+  computeItemUuidsToFetch(itemQuery: ItemQuery, bytesTransferLimit: number): Promise<Array<Uuid>>
+  computeItemUuidBundlesToFetch(itemQuery: ItemQuery, bytesTransferLimit: number): Promise<Array<Array<Uuid>>>
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -781,6 +781,14 @@
     "@standardnotes/common" "^1.17.0"
     jsonwebtoken "^8.5.1"
 
+"@standardnotes/auth@^3.18.5":
+  version "3.18.5"
+  resolved "https://registry.yarnpkg.com/@standardnotes/auth/-/auth-3.18.5.tgz#11087e0bc31c42e489a7f546d317bbbcbd48d573"
+  integrity sha512-NSeU3A9iDyZFLLfv6jOyaweykMbjUUe0XoZo6lVifQucsRW0VJ4R6m3aeXqx6/zDwmHIBqVVzrX2bqQ7r2s9SA==
+  dependencies:
+    "@standardnotes/common" "^1.19.3"
+    jsonwebtoken "^8.5.1"
+
 "@standardnotes/common@1.17.0", "@standardnotes/common@^1.17.0":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@standardnotes/common/-/common-1.17.0.tgz#4f862dae7599bc6541bc259f98f93cd399581175"
@@ -795,6 +803,11 @@
   version "1.16.2"
   resolved "https://registry.yarnpkg.com/@standardnotes/common/-/common-1.16.2.tgz#abdedab6562be06ba1a0ba1e015738cab9a15aa1"
   integrity sha512-81zEVwu2CjX08FMEgNn/klpP1AIGev9nsi9YtLwct2K1D3u9fUsX6AXd7ZvcZ/L0REF8ceXbc1+WmFH5uQUBLw==
+
+"@standardnotes/common@^1.19.3":
+  version "1.19.3"
+  resolved "https://registry.yarnpkg.com/@standardnotes/common/-/common-1.19.3.tgz#ae2ca493492eb5e0d9663abf736a9d7a26365c52"
+  integrity sha512-nMqH+grkIgnODr5EncbG9yHqIxSBHLVTiAb+NZ2EvkhLBiuVhP2UEDNs8KcZKfgNVGGDIHQbjEXZKGog9J6gZw==
 
 "@standardnotes/config@2.1.3":
   version "2.1.3"
@@ -817,13 +830,21 @@
     sqs-consumer "^5.5.0"
     winston "^3.3.3"
 
-"@standardnotes/domain-events@2.23.14", "@standardnotes/domain-events@^2.23.14":
+"@standardnotes/domain-events@^2.23.14":
   version "2.23.14"
   resolved "https://registry.yarnpkg.com/@standardnotes/domain-events/-/domain-events-2.23.14.tgz#733e340c6d42935c90858380d7721150d1804574"
   integrity sha512-DRPD0lGdVn/tbVyl97QGyyAcdUZd4qsETICCO882mG33HBN8Yc7st176U+izu3T5W3dlnTqE+MJUASj3UxVCvw==
   dependencies:
     "@standardnotes/auth" "^3.16.4"
     "@standardnotes/features" "^1.32.11"
+
+"@standardnotes/domain-events@^2.26.11":
+  version "2.26.11"
+  resolved "https://registry.yarnpkg.com/@standardnotes/domain-events/-/domain-events-2.26.11.tgz#709217dd24e51f17fe21756a09938c24953cbd6c"
+  integrity sha512-DYWnO9VVqPCDuagQuRBmbC2tQJ0qZcwZu+yQdcOWQVqchixYSHFPutVxkas7viEYY6xvvV4bIwqf7oabO2TJhw==
+  dependencies:
+    "@standardnotes/auth" "^3.18.5"
+    "@standardnotes/features" "^1.37.3"
 
 "@standardnotes/features@^1.32.11":
   version "1.32.11"
@@ -848,6 +869,14 @@
   dependencies:
     "@standardnotes/auth" "^3.18.0"
     "@standardnotes/common" "^1.17.0"
+
+"@standardnotes/features@^1.37.3":
+  version "1.37.3"
+  resolved "https://registry.yarnpkg.com/@standardnotes/features/-/features-1.37.3.tgz#cf953a99ea79790337c7fe690c439b76e2b5a0e9"
+  integrity sha512-5hBy3Y9EepHuX1lohH9E5+PrPZegbvUbJh/WgYQJjqNurYfSzw9NO4L6z43ZEnPZO+eRoRm4TI7sLLwg/XWdDQ==
+  dependencies:
+    "@standardnotes/auth" "^3.18.5"
+    "@standardnotes/common" "^1.19.3"
 
 "@standardnotes/payloads@^1.4.18":
   version "1.4.18"


### PR DESCRIPTION
## Description

Large data sets should be split into multiple emails to allow sending the email instead of a warning about the backup being too big.

## Related Issue(s)

[Internal link](https://app.asana.com/0/1160985268757888/1201699860731284/f)
