### PR TITLE
feat: trim item projection for saved items

### DIFF
--- a/src/Bootstrap/Container.ts
+++ b/src/Bootstrap/Container.ts
@@ -60,6 +60,13 @@ import { CheckIntegrity } from '../Domain/UseCase/CheckIntegrity/CheckIntegrity'
 import { GetItem } from '../Domain/UseCase/GetItem/GetItem'
 import { ItemTransferCalculatorInterface } from '../Domain/Item/ItemTransferCalculatorInterface'
 import { ItemTransferCalculator } from '../Domain/Item/ItemTransferCalculator'
+import { ProjectorInterface } from '../Projection/ProjectorInterface'
+import { SavedItemProjection } from '../Projection/SavedItemProjection'
+import { SavedItemProjector } from '../Projection/SavedItemProjector'
+import { ItemProjection } from '../Projection/ItemProjection'
+import { RevisionProjection } from '../Projection/RevisionProjection'
+import { ItemConflict } from '../Domain/Item/ItemConflict'
+import { ItemConflictProjection } from '../Projection/ItemConflictProjection'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const newrelicWinstonEnricher = require('@newrelic/winston-enricher')
@@ -174,9 +181,10 @@ export class ContainerConfigLoader {
     container.bind<AuthMiddleware>(TYPES.AuthMiddleware).to(AuthMiddleware)
 
     // Projectors
-    container.bind<RevisionProjector>(TYPES.RevisionProjector).to(RevisionProjector)
-    container.bind<ItemProjector>(TYPES.ItemProjector).to(ItemProjector)
-    container.bind<ItemConflictProjector>(TYPES.ItemConflictProjector).to(ItemConflictProjector)
+    container.bind<ProjectorInterface<Revision, RevisionProjection>>(TYPES.RevisionProjector).to(RevisionProjector)
+    container.bind<ProjectorInterface<Item, ItemProjection>>(TYPES.ItemProjector).to(ItemProjector)
+    container.bind<ProjectorInterface<Item, SavedItemProjection>>(TYPES.SavedItemProjector).to(SavedItemProjector)
+    container.bind<ProjectorInterface<ItemConflict, ItemConflictProjection>>(TYPES.ItemConflictProjector).to(ItemConflictProjector)
 
     // env vars
     container.bind(TYPES.REDIS_URL).toConstantValue(env.get('REDIS_URL'))

--- a/src/Bootstrap/Types.ts
+++ b/src/Bootstrap/Types.ts
@@ -13,6 +13,7 @@ const TYPES = {
   // Projectors
   RevisionProjector: Symbol.for('RevisionProjector'),
   ItemProjector: Symbol.for('ItemProjector'),
+  SavedItemProjector: Symbol.for('SavedItemProjector'),
   ItemConflictProjector: Symbol.for('ItemConflictProjector'),
   // env vars
   REDIS_URL: Symbol.for('REDIS_URL'),

--- a/src/Controller/ItemsController.spec.ts
+++ b/src/Controller/ItemsController.spec.ts
@@ -14,12 +14,13 @@ import { CheckIntegrity } from '../Domain/UseCase/CheckIntegrity/CheckIntegrity'
 import { GetItem } from '../Domain/UseCase/GetItem/GetItem'
 import { Item } from '../Domain/Item/Item'
 import { ProjectorInterface } from '../Projection/ProjectorInterface'
+import { ItemProjection } from '../Projection/ItemProjection'
 
 describe('ItemsController', () => {
   let syncItems: SyncItems
   let checkIntegrity: CheckIntegrity
   let getItem: GetItem
-  let itemProjector: ProjectorInterface<Item>
+  let itemProjector: ProjectorInterface<Item, ItemProjection>
   let request: express.Request
   let response: express.Response
   let syncResponceFactoryResolver: SyncResponseFactoryResolverInterface
@@ -35,7 +36,7 @@ describe('ItemsController', () => {
   )
 
   beforeEach(() => {
-    itemProjector = {} as jest.Mocked<ProjectorInterface<Item>>
+    itemProjector = {} as jest.Mocked<ProjectorInterface<Item, ItemProjection>>
     itemProjector.projectFull = jest.fn().mockReturnValue({ foo: 'bar' })
 
     syncItems = {} as jest.Mocked<SyncItems>

--- a/src/Controller/ItemsController.ts
+++ b/src/Controller/ItemsController.ts
@@ -8,6 +8,7 @@ import { SyncResponseFactoryResolverInterface } from '../Domain/Item/SyncRespons
 import { CheckIntegrity } from '../Domain/UseCase/CheckIntegrity/CheckIntegrity'
 import { GetItem } from '../Domain/UseCase/GetItem/GetItem'
 import { SyncItems } from '../Domain/UseCase/SyncItems'
+import { ItemProjection } from '../Projection/ItemProjection'
 import { ProjectorInterface } from '../Projection/ProjectorInterface'
 
 @controller('/items', TYPES.AuthMiddleware)
@@ -16,7 +17,7 @@ export class ItemsController extends BaseHttpController {
     @inject(TYPES.SyncItems) private syncItems: SyncItems,
     @inject(TYPES.CheckIntegrity) private checkIntegrity: CheckIntegrity,
     @inject(TYPES.GetItem) private getItem: GetItem,
-    @inject(TYPES.ItemProjector) private itemProjector: ProjectorInterface<Item>,
+    @inject(TYPES.ItemProjector) private itemProjector: ProjectorInterface<Item, ItemProjection>,
     @inject(TYPES.SyncResponseFactoryResolver) private syncResponseFactoryResolver: SyncResponseFactoryResolverInterface,
   ) {
     super()

--- a/src/Controller/RevisionsController.spec.ts
+++ b/src/Controller/RevisionsController.spec.ts
@@ -7,9 +7,10 @@ import { RevisionsController } from './RevisionsController'
 import { results } from 'inversify-express-utils'
 import { ProjectorInterface } from '../Projection/ProjectorInterface'
 import { RevisionServiceInterface } from '../Domain/Revision/RevisionServiceInterface'
+import { RevisionProjection } from '../Projection/RevisionProjection'
 
 describe('RevisionsController', () => {
-  let revisionProjector: ProjectorInterface<Revision>
+  let revisionProjector: ProjectorInterface<Revision, RevisionProjection>
   let revisionService: RevisionServiceInterface
   let revision: Revision
   let request: express.Request
@@ -20,7 +21,7 @@ describe('RevisionsController', () => {
   beforeEach(() => {
     revision = {} as jest.Mocked<Revision>
 
-    revisionProjector = {} as jest.Mocked<ProjectorInterface<Revision>>
+    revisionProjector = {} as jest.Mocked<ProjectorInterface<Revision, RevisionProjection>>
 
     revisionService = {} as jest.Mocked<RevisionServiceInterface>
     revisionService.getRevisions = jest.fn().mockReturnValue([ revision ])

--- a/src/Controller/RevisionsController.ts
+++ b/src/Controller/RevisionsController.ts
@@ -7,12 +7,13 @@ import { ProjectorInterface } from '../Projection/ProjectorInterface'
 import { Revision } from '../Domain/Revision/Revision'
 import { RevisionServiceInterface } from '../Domain/Revision/RevisionServiceInterface'
 import { ErrorTag } from '@standardnotes/common'
+import { RevisionProjection } from '../Projection/RevisionProjection'
 
 @controller('/items/:itemUuid/revisions', TYPES.AuthMiddleware)
 export class RevisionsController extends BaseHttpController {
   constructor(
     @inject(TYPES.RevisionService) private revisionService: RevisionServiceInterface,
-    @inject(TYPES.RevisionProjector) private revisionProjector: ProjectorInterface<Revision>
+    @inject(TYPES.RevisionProjector) private revisionProjector: ProjectorInterface<Revision, RevisionProjection>
   ) {
     super()
   }

--- a/src/Domain/Item/SyncResponse/SyncResponse20200115.ts
+++ b/src/Domain/Item/SyncResponse/SyncResponse20200115.ts
@@ -1,9 +1,10 @@
 import { ItemConflictProjection } from '../../../Projection/ItemConflictProjection'
 import { ItemProjection } from '../../../Projection/ItemProjection'
+import { SavedItemProjection } from '../../../Projection/SavedItemProjection'
 
 export type SyncResponse20200115 = {
   retrieved_items: Array<ItemProjection>
-  saved_items: Array<ItemProjection>
+  saved_items: Array<SavedItemProjection>
   conflicts: Array<ItemConflictProjection>
   sync_token: string
   cursor_token?: string

--- a/src/Domain/Item/SyncResponse/SyncResponseFactory20161215.spec.ts
+++ b/src/Domain/Item/SyncResponse/SyncResponseFactory20161215.spec.ts
@@ -8,7 +8,7 @@ import { SyncResponseFactory20161215 } from './SyncResponseFactory20161215'
 import { ConflictType } from '@standardnotes/responses'
 
 describe('SyncResponseFactory20161215', () => {
-  let itemProjector: ProjectorInterface<Item>
+  let itemProjector: ProjectorInterface<Item, ItemProjection>
   let item1Projection: ItemProjection
   let item2Projection: ItemProjection
   let item1: Item
@@ -24,7 +24,7 @@ describe('SyncResponseFactory20161215', () => {
       uuid: '2-3-4',
     } as jest.Mocked<ItemProjection>
 
-    itemProjector = {} as jest.Mocked<ProjectorInterface<Item>>
+    itemProjector = {} as jest.Mocked<ProjectorInterface<Item, ItemProjection>>
     itemProjector.projectFull = jest.fn().mockImplementation((item: Item) => {
       if (item.uuid === '1-2-3') {
         return item1Projection

--- a/src/Domain/Item/SyncResponse/SyncResponseFactory20161215.ts
+++ b/src/Domain/Item/SyncResponse/SyncResponseFactory20161215.ts
@@ -15,7 +15,7 @@ export class SyncResponseFactory20161215 implements SyncResponseFactoryInterface
   private readonly LEGACY_MIN_CONFLICT_INTERVAL = 20_000_000
 
   constructor(
-    @inject(TYPES.ItemProjector) private itemProjector: ProjectorInterface<Item>,
+    @inject(TYPES.ItemProjector) private itemProjector: ProjectorInterface<Item, ItemProjection>,
   ){
   }
 

--- a/src/Domain/Item/SyncResponse/SyncResponseFactory20200115.spec.ts
+++ b/src/Domain/Item/SyncResponse/SyncResponseFactory20200115.spec.ts
@@ -6,24 +6,38 @@ import { ItemConflictProjection } from '../../../Projection/ItemConflictProjecti
 import { ItemProjection } from '../../../Projection/ItemProjection'
 
 import { SyncResponseFactory20200115 } from './SyncResponseFactory20200115'
+import { SavedItemProjection } from '../../../Projection/SavedItemProjection'
 
 describe('SyncResponseFactory20200115', () => {
-  let itemProjector: ProjectorInterface<Item>
-  let itemConflictProjector: ProjectorInterface<ItemConflict>
+  let itemProjector: ProjectorInterface<Item, ItemProjection>
+  let savedItemProjector: ProjectorInterface<Item, SavedItemProjection>
+  let itemConflictProjector: ProjectorInterface<ItemConflict, ItemConflictProjection>
   let itemProjection: ItemProjection
+  let savedItemProjection: SavedItemProjection
   let itemConflictProjection: ItemConflictProjection
   let item1: Item
   let item2: Item
   let itemConflict: ItemConflict
 
-  const createFactory = () => new SyncResponseFactory20200115(itemProjector, itemConflictProjector)
+  const createFactory = () => new SyncResponseFactory20200115(itemProjector, itemConflictProjector, savedItemProjector)
 
   beforeEach(() => {
-    itemProjector = {} as jest.Mocked<ProjectorInterface<Item>>
+    itemProjection = {
+      uuid: '2-3-4',
+    } as jest.Mocked<ItemProjection>
+
+    itemProjector = {} as jest.Mocked<ProjectorInterface<Item, ItemProjection>>
     itemProjector.projectFull = jest.fn().mockReturnValue(itemProjection)
 
-    itemConflictProjector = {} as jest.Mocked<ProjectorInterface<ItemConflict>>
+    itemConflictProjector = {} as jest.Mocked<ProjectorInterface<ItemConflict, ItemConflictProjection>>
     itemConflictProjector.projectFull = jest.fn().mockReturnValue(itemConflictProjection)
+
+    savedItemProjection = {
+      uuid: '1-2-3',
+    } as jest.Mocked<SavedItemProjection>
+
+    savedItemProjector = {} as jest.Mocked<ProjectorInterface<Item, SavedItemProjection>>
+    savedItemProjector.projectFull = jest.fn().mockReturnValue(savedItemProjection)
 
     item1 = {} as jest.Mocked<Item>
 
@@ -42,7 +56,7 @@ describe('SyncResponseFactory20200115', () => {
       cursorToken: 'cursor-test',
     })).toEqual({
       retrieved_items: [ itemProjection ],
-      saved_items: [ itemProjection ],
+      saved_items: [ savedItemProjection ],
       conflicts: [ itemConflictProjection ],
       sync_token: 'sync-test',
       integrity_hash: 'test-hash',

--- a/src/Domain/Item/SyncResponse/SyncResponseFactory20200115.ts
+++ b/src/Domain/Item/SyncResponse/SyncResponseFactory20200115.ts
@@ -8,12 +8,14 @@ import { ItemConflictProjection } from '../../../Projection/ItemConflictProjecti
 import { ItemProjection } from '../../../Projection/ItemProjection'
 import { SyncResponse20200115 } from './SyncResponse20200115'
 import { SyncResponseFactoryInterface } from './SyncResponseFactoryInterface'
+import { SavedItemProjection } from '../../../Projection/SavedItemProjection'
 
 @injectable()
 export class SyncResponseFactory20200115 implements SyncResponseFactoryInterface {
   constructor(
-    @inject(TYPES.ItemProjector) private itemProjector: ProjectorInterface<Item>,
-    @inject(TYPES.ItemConflictProjector) private itemConflictProjector: ProjectorInterface<ItemConflict>,
+    @inject(TYPES.ItemProjector) private itemProjector: ProjectorInterface<Item, ItemProjection>,
+    @inject(TYPES.ItemConflictProjector) private itemConflictProjector: ProjectorInterface<ItemConflict, ItemConflictProjection>,
+    @inject(TYPES.SavedItemProjector) private savedItemProjector: ProjectorInterface<Item, SavedItemProjection>,
   ){
   }
 
@@ -25,7 +27,7 @@ export class SyncResponseFactory20200115 implements SyncResponseFactoryInterface
 
     const savedItems = []
     for (const item of syncItemsResponse.savedItems) {
-      savedItems.push(<ItemProjection> await this.itemProjector.projectFull(item))
+      savedItems.push(<SavedItemProjection> await this.savedItemProjector.projectFull(item))
     }
 
     const conflicts = []

--- a/src/Infra/S3/S3ItemBackupService.spec.ts
+++ b/src/Infra/S3/S3ItemBackupService.spec.ts
@@ -6,10 +6,11 @@ import { Logger } from 'winston'
 import { Item } from '../../Domain/Item/Item'
 import { S3ItemBackupService } from './S3ItemBackupService'
 import { ProjectorInterface } from '../../Projection/ProjectorInterface'
+import { ItemProjection } from '../../Projection/ItemProjection'
 
 describe('S3ItemBackupService', () => {
   let s3Client: S3 | undefined
-  let itemProjector: ProjectorInterface<Item>
+  let itemProjector: ProjectorInterface<Item, ItemProjection>
   let s3BackupBucketName = 'backup-bucket'
   let logger: Logger
   let item: Item
@@ -35,7 +36,7 @@ describe('S3ItemBackupService', () => {
 
     keyParams = {} as jest.Mocked<KeyParamsData>
 
-    itemProjector = {} as jest.Mocked<ProjectorInterface<Item>>
+    itemProjector = {} as jest.Mocked<ProjectorInterface<Item, ItemProjection>>
     itemProjector.projectFull = jest.fn().mockReturnValue({ foo: 'bar' })
   })
 

--- a/src/Infra/S3/S3ItemBackupService.ts
+++ b/src/Infra/S3/S3ItemBackupService.ts
@@ -7,12 +7,13 @@ import TYPES from '../../Bootstrap/Types'
 import { Item } from '../../Domain/Item/Item'
 import { ItemBackupServiceInterface } from '../../Domain/Item/ItemBackupServiceInterface'
 import { ProjectorInterface } from '../../Projection/ProjectorInterface'
+import { ItemProjection } from '../../Projection/ItemProjection'
 
 @injectable()
 export class S3ItemBackupService implements ItemBackupServiceInterface {
   constructor (
     @inject(TYPES.S3_BACKUP_BUCKET_NAME) private s3BackupBucketName: string,
-    @inject(TYPES.ItemProjector) private itemProjector: ProjectorInterface<Item>,
+    @inject(TYPES.ItemProjector) private itemProjector: ProjectorInterface<Item, ItemProjection>,
     @inject(TYPES.Logger) private logger: Logger,
     @inject(TYPES.S3) private s3Client?: S3,
   ) {

--- a/src/Projection/ItemConflictProjector.spec.ts
+++ b/src/Projection/ItemConflictProjector.spec.ts
@@ -9,7 +9,7 @@ import { ItemProjection } from './ItemProjection'
 import { ConflictType } from '@standardnotes/responses'
 
 describe('ItemConflictProjector', () => {
-  let itemProjector: ProjectorInterface<Item>
+  let itemProjector: ProjectorInterface<Item, ItemProjection>
   let itemProjection: ItemProjection
   let itemConflict1: ItemConflict
   let itemConflict2: ItemConflict
@@ -21,7 +21,7 @@ describe('ItemConflictProjector', () => {
   beforeEach(() => {
     itemProjection = {} as jest.Mocked<ItemProjection>
 
-    itemProjector = {} as jest.Mocked<ProjectorInterface<Item>>
+    itemProjector = {} as jest.Mocked<ProjectorInterface<Item, ItemProjection>>
     itemProjector.projectFull = jest.fn().mockReturnValue(itemProjection)
 
     item = {} as jest.Mocked<Item>

--- a/src/Projection/ItemConflictProjector.ts
+++ b/src/Projection/ItemConflictProjector.ts
@@ -8,17 +8,17 @@ import { ItemConflictProjection } from './ItemConflictProjection'
 import { ItemProjection } from './ItemProjection'
 
 @injectable()
-export class ItemConflictProjector implements ProjectorInterface<ItemConflict> {
+export class ItemConflictProjector implements ProjectorInterface<ItemConflict, ItemConflictProjection> {
   constructor(
-    @inject(TYPES.ItemProjector) private itemProjector: ProjectorInterface<Item>,
+    @inject(TYPES.ItemProjector) private itemProjector: ProjectorInterface<Item, ItemProjection>,
   ) {
   }
 
-  async projectSimple(_itemConflict: ItemConflict): Promise<Record<string, unknown>> {
+  async projectSimple(_itemConflict: ItemConflict): Promise<ItemConflictProjection> {
     throw Error('not implemented')
   }
 
-  async projectCustom(_projectionType: string, _itemConflict: ItemConflict): Promise<Record<string, unknown>> {
+  async projectCustom(_projectionType: string, _itemConflict: ItemConflict): Promise<ItemConflictProjection> {
     throw Error('not implemented')
   }
 

--- a/src/Projection/ProjectorInterface.ts
+++ b/src/Projection/ProjectorInterface.ts
@@ -1,5 +1,5 @@
-export interface ProjectorInterface<T> {
-  projectSimple(object: T): Promise<Record<string, unknown>>
-  projectFull(object: T): Promise<Record<string, unknown>>
-  projectCustom(projectionType: string, object: T, ...args: any[]): Promise<Record<string, unknown>>
+export interface ProjectorInterface<T, E> {
+  projectSimple(object: T): Promise<Partial<E>>
+  projectFull(object: T): Promise<E>
+  projectCustom(projectionType: string, object: T, ...args: any[]): Promise<E>
 }

--- a/src/Projection/RevisionProjection.ts
+++ b/src/Projection/RevisionProjection.ts
@@ -1,0 +1,15 @@
+import { RoleName } from '@standardnotes/common'
+
+export type RevisionProjection = {
+  uuid: string
+  item_uuid: string
+  content: string | null
+  content_type: string
+  items_key_id: string | null
+  enc_item_key: string | null
+  auth_hash: string | null
+  creation_date: string
+  required_role: RoleName
+  created_at: string
+  updated_at: string
+}

--- a/src/Projection/RevisionProjector.ts
+++ b/src/Projection/RevisionProjector.ts
@@ -5,16 +5,18 @@ import TYPES from '../Bootstrap/Types'
 import { Revision } from '../Domain/Revision/Revision'
 import { RevisionServiceInterface } from '../Domain/Revision/RevisionServiceInterface'
 import { ProjectorInterface } from './ProjectorInterface'
+import { RevisionProjection } from './RevisionProjection'
+import { SimpleRevisionProjection } from './SimpleRevisionProjection'
 
 @injectable()
-export class RevisionProjector implements ProjectorInterface<Revision> {
+export class RevisionProjector implements ProjectorInterface<Revision, RevisionProjection> {
   constructor(
     @inject(TYPES.Timer) private timer: TimerInterface,
     @inject(TYPES.RevisionService) private revisionService: RevisionServiceInterface,
   ) {
   }
 
-  async projectSimple(revision: Revision): Promise<Record<string, unknown>> {
+  async projectSimple(revision: Revision): Promise<SimpleRevisionProjection> {
     return {
       'uuid': revision.uuid,
       'content_type': revision.contentType,
@@ -24,7 +26,7 @@ export class RevisionProjector implements ProjectorInterface<Revision> {
     }
   }
 
-  async projectFull(revision: Revision): Promise<Record<string, unknown>> {
+  async projectFull(revision: Revision): Promise<RevisionProjection> {
     return {
       'uuid': revision.uuid,
       'item_uuid': (await revision.item).uuid,
@@ -40,7 +42,7 @@ export class RevisionProjector implements ProjectorInterface<Revision> {
     }
   }
 
-  async projectCustom(_projectionType: string, _revision: Revision, ..._args: any[]): Promise<Record<string, unknown>> {
+  async projectCustom(_projectionType: string, _revision: Revision, ..._args: any[]): Promise<RevisionProjection> {
     throw new Error('not implemented')
   }
 }

--- a/src/Projection/SavedItemProjection.ts
+++ b/src/Projection/SavedItemProjection.ts
@@ -1,0 +1,11 @@
+export type SavedItemProjection = {
+  uuid: string
+  duplicate_of: string | null
+  content_type: string
+  auth_hash: string | null
+  deleted: boolean
+  created_at: string
+  created_at_timestamp: number
+  updated_at: string
+  updated_at_timestamp: number
+}

--- a/src/Projection/SavedItemProjector.spec.ts
+++ b/src/Projection/SavedItemProjector.spec.ts
@@ -1,0 +1,63 @@
+import 'reflect-metadata'
+import { TimerInterface } from '@standardnotes/time'
+
+import { Item } from '../Domain/Item/Item'
+import { SavedItemProjector } from './SavedItemProjector'
+
+describe('SavedItemProjector', () => {
+  let item: Item
+  let timer: TimerInterface
+
+  const createProjector = () => new SavedItemProjector(timer)
+
+  beforeEach(() => {
+    timer = {} as jest.Mocked<TimerInterface>
+    timer.convertMicrosecondsToStringDate = jest.fn().mockReturnValue('2021-04-15T08:00:00.123456Z')
+
+    item = new Item()
+    item.uuid = '1-2-3'
+    item.itemsKeyId = '2-3-4'
+    item.duplicateOf = null
+    item.encItemKey = '3-4-5'
+    item.content = 'test'
+    item.contentType = 'Note'
+    item.authHash = 'asd'
+    item.deleted = false
+    item.createdAtTimestamp = 123
+    item.updatedAtTimestamp = 123
+  })
+
+  it('should create a full projection of an item', async () => {
+    expect(await createProjector().projectFull(item)).toEqual({
+      uuid: '1-2-3',
+      duplicate_of: null,
+      content_type: 'Note',
+      auth_hash: 'asd',
+      deleted: false,
+      created_at: '2021-04-15T08:00:00.123456Z',
+      created_at_timestamp: 123,
+      updated_at: '2021-04-15T08:00:00.123456Z',
+      updated_at_timestamp: 123,
+    })
+  })
+
+  it('should throw error on custom projection', async () => {
+    let error = null
+    try {
+      await createProjector().projectCustom('test', item)
+    } catch (e) {
+      error = e
+    }
+    expect(error.message).toEqual('not implemented')
+  })
+
+  it('should throw error on simple projection', async () => {
+    let error = null
+    try {
+      await createProjector().projectSimple(item)
+    } catch (e) {
+      error = e
+    }
+    expect(error.message).toEqual('not implemented')
+  })
+})

--- a/src/Projection/SavedItemProjector.ts
+++ b/src/Projection/SavedItemProjector.ts
@@ -4,30 +4,27 @@ import TYPES from '../Bootstrap/Types'
 import { ProjectorInterface } from './ProjectorInterface'
 
 import { Item } from '../Domain/Item/Item'
-import { ItemProjection } from './ItemProjection'
+import { SavedItemProjection } from './SavedItemProjection'
 
 @injectable()
-export class ItemProjector implements ProjectorInterface<Item, ItemProjection> {
+export class SavedItemProjector implements ProjectorInterface<Item, SavedItemProjection> {
   constructor(
     @inject(TYPES.Timer) private timer: TimerInterface,
   ) {
   }
 
-  async projectSimple(_item: Item): Promise<ItemProjection> {
+  async projectSimple(_item: Item): Promise<SavedItemProjection> {
     throw Error('not implemented')
   }
 
-  async projectCustom(_projectionType: string, _item: Item): Promise<ItemProjection> {
+  async projectCustom(_projectionType: string, _item: Item): Promise<SavedItemProjection> {
     throw Error('not implemented')
   }
 
-  async projectFull(item: Item): Promise<ItemProjection> {
+  async projectFull(item: Item): Promise<SavedItemProjection> {
     return {
       uuid: item.uuid,
-      items_key_id: item.itemsKeyId,
       duplicate_of: item.duplicateOf,
-      enc_item_key: item.encItemKey,
-      content: item.content,
       content_type: item.contentType as string,
       auth_hash: item.authHash,
       deleted: !!item.deleted,

--- a/src/Projection/SimpleRevisionProjection.ts
+++ b/src/Projection/SimpleRevisionProjection.ts
@@ -1,0 +1,9 @@
+import { RoleName } from '@standardnotes/common'
+
+export type SimpleRevisionProjection = {
+  uuid: string
+  content_type: string
+  required_role: RoleName
+  created_at: string
+  updated_at: string
+}


### PR DESCRIPTION
## Description

Trim saved items projection from content as it is redundant to return it back to the clients.

## Related Issue(s)

[Internal Link](https://app.asana.com/0/1160985268757881/1202095013010367/f)
